### PR TITLE
Added POST support to request_tracker

### DIFF
--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -3,6 +3,8 @@ package samlsp
 import (
 	"bytes"
 	"encoding/xml"
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/crewjam/saml"
@@ -193,24 +195,31 @@ func (m *Middleware) HandleStartAuthFlow(w http.ResponseWriter, r *http.Request)
 
 // CreateSessionFromAssertion is invoked by ServeHTTP when we have a new, valid SAML assertion.
 func (m *Middleware) CreateSessionFromAssertion(w http.ResponseWriter, r *http.Request, assertion *saml.Assertion, redirectURI string) {
+	var err error
+
+	trackedRequest := &TrackedRequest{
+		Method: "GET",
+		URI:    redirectURI,
+	}
+
 	if trackedRequestIndex := r.Form.Get("RelayState"); trackedRequestIndex != "" {
-		trackedRequest, err := m.RequestTracker.GetTrackedRequest(r, trackedRequestIndex)
+		trackedRequest, err = m.RequestTracker.GetTrackedRequest(r, trackedRequestIndex)
 		if err != nil {
-			if err == http.ErrNoCookie && m.ServiceProvider.AllowIDPInitiated {
-				if uri := r.Form.Get("RelayState"); uri != "" {
-					redirectURI = uri
+			if errors.Is(err, http.ErrNoCookie) && m.ServiceProvider.AllowIDPInitiated {
+				// We don't need to re-read RelayState from the form and check it for nil. The test above did that
+				trackedRequest = &TrackedRequest{
+					Method: "GET",
+					URI:    trackedRequestIndex,
 				}
 			} else {
 				m.OnError(w, r, err)
 				return
 			}
 		} else {
-			if err := m.RequestTracker.StopTrackingRequest(w, r, trackedRequestIndex); err != nil {
+			if err = m.RequestTracker.StopTrackingRequest(w, r, trackedRequestIndex); err != nil {
 				m.OnError(w, r, err)
 				return
 			}
-
-			redirectURI = trackedRequest.URI
 		}
 	}
 
@@ -218,8 +227,32 @@ func (m *Middleware) CreateSessionFromAssertion(w http.ResponseWriter, r *http.R
 		m.OnError(w, r, err)
 		return
 	}
+	m.HandleRedirectAfterAssertion(w, r, trackedRequest)
+}
 
-	http.Redirect(w, r, redirectURI, http.StatusFound)
+// HandleRedirectAfterAssertion is called after we've handled receiving a SAML assertion and created a session with the
+// browser. Most normal cases are just a redirect, but if the original request was a POST, it's a little more tricky.
+func (m *Middleware) HandleRedirectAfterAssertion(w http.ResponseWriter, r *http.Request, trackedRequest *TrackedRequest) {
+	switch trackedRequest.Method {
+	case "POST":
+		text := fmt.Sprintf(`<html>`+
+			`<form method="post" action="%s" id="SAMLAfterAssertionRedirectForm">`, trackedRequest.URI)
+		for key, values := range trackedRequest.PostData {
+			for _, value := range values {
+				text = fmt.Sprintf(`%s<input type="hidden" name="%s" value="%s" />`, text, key, value)
+			}
+		}
+		text += `<input id="SAMLAfterAssertionRedirectSubmitButton" type="submit" value="Continue" />` +
+			`</form>` +
+			`<script>document.getElementById('SAMLAfterAssertionRedirectSubmitButton').style.visibility='hidden';</script>` +
+			`<script>document.getElementById('SAMLAfterAssertionRedirectForm').submit();</script>` +
+			`</html>`
+
+		w.Write([]byte(text))
+		return
+	default:
+		http.Redirect(w, r, trackedRequest.URI, http.StatusFound)
+	}
 }
 
 // RequireAttribute returns a middleware function that requires that the

--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -250,6 +250,7 @@ func (m *Middleware) HandleRedirectAfterAssertion(w http.ResponseWriter, r *http
 
 		w.Write([]byte(text))
 		return
+		// TODO: Handle HEAD, DELETE, etc.
 	default:
 		http.Redirect(w, r, trackedRequest.URI, http.StatusFound)
 	}

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -115,6 +115,7 @@ func (test *MiddlewareTest) makeTrackedRequest(id string) string {
 		Index:         "KCosLjAyNDY4Ojw-QEJERkhKTE5QUlRWWFpcXmBiZGZoamxucHJ0dnh6",
 		SAMLRequestID: id,
 		URI:           "/frob",
+		Method:        "GET",
 	})
 	if err != nil {
 		panic(err)

--- a/samlsp/request_tracker.go
+++ b/samlsp/request_tracker.go
@@ -2,6 +2,7 @@ package samlsp
 
 import (
 	"net/http"
+	"net/url"
 )
 
 // RequestTracker tracks pending authentication requests.
@@ -31,9 +32,11 @@ type RequestTracker interface {
 
 // TrackedRequest holds the data we store for each pending request.
 type TrackedRequest struct {
-	Index         string `json:"-"`
-	SAMLRequestID string `json:"id"`
-	URI           string `json:"uri"`
+	Index         string     `json:"-"`
+	SAMLRequestID string     `json:"id"`
+	URI           string     `json:"uri"`
+	Method        string     `json:"method"`
+	PostData      url.Values `json:"post_data"`
 }
 
 // TrackedRequestCodec handles encoding and decoding of a TrackedRequest.

--- a/samlsp/request_tracker_cookie.go
+++ b/samlsp/request_tracker_cookie.go
@@ -26,10 +26,15 @@ type CookieRequestTracker struct {
 // TrackRequest starts tracking the SAML request with the given ID. It returns an
 // `index` that should be used as the RelayState in the SAMl request flow.
 func (t CookieRequestTracker) TrackRequest(w http.ResponseWriter, r *http.Request, samlRequestID string) (string, error) {
+	if r.Method == "POST" {
+		r.ParseForm()
+	}
 	trackedRequest := TrackedRequest{
 		Index:         base64.RawURLEncoding.EncodeToString(randomBytes(42)),
 		SAMLRequestID: samlRequestID,
 		URI:           r.URL.String(),
+		Method:        r.Method,
+		PostData:      r.PostForm,
 	}
 
 	if t.RelayStateFunc != nil {


### PR DESCRIPTION
In the case where you've used samlsp to wrap an endpoint that may get a POST request, the previous implemetation just did a HTTP Redirect after the SAML assertion was done.